### PR TITLE
DELIVERY: Change host port for backend

### DIFF
--- a/backend/delivery/Jenkinsfile
+++ b/backend/delivery/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                         sh '''
                         docker run -d \
                             --name ${IMAGE_NAME} \
-                            -p 8080:8080 \
+                            -p 8089:8080 \
                             ${IMAGE_NAME}:${IMAGE_TAG}
                         '''
                     }


### PR DESCRIPTION
This adjusts the host port for the backend to 8089. We will likely expose the frontend on 8088.