### PR TITLE
FEATURE: Add support for GET all user data

### DIFF
--- a/backend/src/main/java/com/capstone/studentplacementplatform/service/UserService.java
+++ b/backend/src/main/java/com/capstone/studentplacementplatform/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -30,7 +31,7 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
-    public void registerUser(RegistrationRequest request) {
+    public User registerUser(RegistrationRequest request) {
         User user = new User();
         user.setEmail(request.getEmail());
         user.setUsername(request.getUsername());
@@ -40,6 +41,11 @@ public class UserService {
         user.setRole(request.getRole().toUpperCase());
 
         userRepository.save(user);
+        return user;
+    }
+
+    public List<User> findAll() {
+        return userRepository.findAll();
     }
 
     public Optional<User> findById(Long userId) {


### PR DESCRIPTION
This adds support to allow someone to get all data for all users. e.g.
```
curl -X GET http://localhost:8089/api/v1/users | jq
[
  {
    "id": 1,
    "firstName": "John",
    "lastName": "Doe",
    "username": "john_doe",
    "email": "john@example.com",
    "password": "REDACTED",
    "role": "STUDENT"
  },
  {
    "id": 2,
    "firstName": "Johnn",
    "lastName": "Doee",
    "username": "john_doee",
    "email": "johnn@example.com",
    "password": "REDACTED",
    "role": "STUDENT"
  }
]
```