### PR TITLE
BUGFIX: Adjusting frontend Dockerfile and adding Nginx.conf

### DIFF
--- a/frontend/delivery/Dockerfile
+++ b/frontend/delivery/Dockerfile
@@ -1,15 +1,15 @@
 # Stage 1: Build the React app
-FROM node:14-alpine AS build
+FROM node:18-alpine AS build
 
 WORKDIR /app
 
 COPY ../student-placement-platform/package*.json ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY student-placement-platform/ ./
 
-RUN npm run build
+RUN npm run build --legacy-peer-deps
 
 
 
@@ -17,6 +17,7 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/build /usr/share/nginx/html
+COPY /delivery/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/frontend/delivery/nginx.conf
+++ b/frontend/delivery/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
Bumping node version, adding --legacy-peer-deps for installations, and including new Nginx.conf and copying to the Dockerfile to fix React routing issues (described here for example: https://www.frontendundefined.com/posts/tutorials/nginx-react-router-404/)
```
If you are using Nginx to host a React app with React Router, you might come across a 404 error when you directly load a React Router Route. For example, if you have a route with the path /about-us, it might work when you load the root route / and navigate to /about-us by clicking on a link but it will return a 404 when you try to load /about-us directly
```